### PR TITLE
fix(rpc): fix nil pointer error

### DIFF
--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -512,6 +512,10 @@ func (r *RPCServer) BroadcastTxSync(ctx context.Context, tx cmttypes.Tx) (*coret
 	// Note: we have to do this here because, unlike the tendermint mempool reactor, there
 	// is no routine that gossips transactions after they enter the pool
 	if res.Code == abci.CodeTypeOK {
+		if r.adapter.TxGossiper == nil {
+			return nil, fmt.Errorf("tx gossiper is not ready")
+		}
+
 		err = r.adapter.TxGossiper.Publish(ctx, tx)
 		if err != nil {
 			// the transaction must be removed from the mempool if it cannot be gossiped.

--- a/server/start.go
+++ b/server/start.go
@@ -365,7 +365,7 @@ func startNode(
 		cmtGenDoc.ChainID,
 		uint64(cmtGenDoc.InitialHeight),
 		cmtGenDoc.GenesisTime,
-		cmtGenDoc.Validators[0].Address, // use the first validator as sequencer
+		cmtGenDoc.Validators[0].Address.Bytes(), // use the first validator as sequencer
 	)
 
 	dalc, err := goda.NewClient(rollkitcfg.DA.Address, rollkitcfg.DA.AuthToken)
@@ -413,8 +413,7 @@ func startNode(
 
 	// executor must be started after the node is started
 	logger.Info("starting executor")
-	err = executor.Start(ctx)
-	if err != nil {
+	if err = executor.Start(ctx); err != nil {
 		return nil, nil, cleanupFn, fmt.Errorf("failed to start executor: %w", err)
 	}
 


### PR DESCRIPTION
ref: https://github.com/rollkit/go-execution-abci/issues/27

Posting a tx too closer after node starting would panic:

```go
2025/04/22 18:46:48 http: panic serving [::1]:53472: runtime error: invalid memory address or nil pointer dereference
goroutine 340 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1947 +0xb0
panic({0x39c7aa0?, 0x7a12e40?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/rollkit/go-execution-abci/p2p.(*Gossiper).Publish(0x4003ec00d0?, {0x51d4b58?, 0x4001cb2e60?}, {0x40036e6000?, 0x4003685f20?, 0x2?})
        /home/julien/projects/rollkit/go-execution-abci/p2p/gossip.go:87 +0x24
github.com/rollkit/go-execution-abci/rpc.(*RPCServer).BroadcastTxSync(0x4001536160, {0x51d4b58, 0x4001cb2e60}, {0x40036e6000, 0x12c, 0x12c})
        /home/julien/projects/rollkit/go-execution-abci/rpc/rpc.go:515 +0x11c
github.com/rollkit/go-execution-abci/rpc/json.(*service).BroadcastTxSync(0x4?, 0x4001e1dc90?, 0x2?)
        /home/julien/projects/rollkit/go-execution-abci/rpc/json/service.go:345 +0x58
reflect.Value.call({0x39ab820?, 0x4002c9a860?, 0x3751120?}, {0x41f9770, 0x4}, {0x40030ef968, 0x2, 0x199?})
        /usr/local/go/src/reflect/value.go:584 +0x978
reflect.Value.Call({0x39ab820?, 0x4002c9a860?, 0x4001baafc0?}, {0x40030ef968?, 0x4001e1d895?, 0x4001e1d900?})
        /usr/local/go/src/reflect/value.go:368 +0x94
github.com/rollkit/go-execution-abci/rpc/json.(*handler).serveJSONRPCforWS(0x4002ae3620, {0x51bdee0, 0x4002a57b20}, 0x40030d3180, 0x0)
        /home/julien/projects/rollkit/go-execution-abci/rpc/json/handler.go:95 +0x348
github.com/rollkit/go-execution-abci/rpc/json.(*handler).serveJSONRPC(...)
        /home/julien/projects/rollkit/go-execution-abci/rpc/json/handler.go:53
net/http.HandlerFunc.ServeHTTP(0x400147e000?, {0x51bdee0?, 0x4002a57b20?}, 0x0?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
net/http.(*ServeMux).ServeHTTP(0x40030efab8?, {0x51bdee0, 0x4002a57b20}, 0x40030d3180)
        /usr/local/go/src/net/http/server.go:2822 +0x1b4
github.com/rollkit/go-execution-abci/rpc/json.(*handler).ServeHTTP(0x4002a80820?, {0x51bdee0?, 0x4002a57b20?}, 0x40030d3180?)
        /home/julien/projects/rollkit/go-execution-abci/rpc/json/handler.go:48 +0x28
github.com/rollkit/go-execution-abci/rpc.(*RPCServer).startRPC.(*Cors).Handler.func2({0x51bdee0, 0x4002a57b20}, 0x40030d3180)
        /var/cache/go/github.com/rs/cors@v1.11.1/cors.go:289 +0x19c
net/http.HandlerFunc.ServeHTTP(0x10?, {0x51bdee0?, 0x4002a57b20?}, 0x4002a57b20?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
net/http.serverHandler.ServeHTTP({0x51a5268?}, {0x51bdee0?, 0x4002a57b20?}, 0x1?)
        /usr/local/go/src/net/http/server.go:3301 +0xbc
net/http.(*conn).serve(0x4002813200, {0x51d4b20, 0x40045e8390})
        /usr/local/go/src/net/http/server.go:2102 +0x52c
created by net/http.(*Server).Serve in goroutine 25
        /usr/local/go/src/net/http/server.go:3454 +0x3d8
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction broadcasting reliability by preventing operations when the transaction gossiper is not ready, reducing potential errors.

- **Refactor**
  - Streamlined error handling during node startup for clearer and more concise code execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->