### PR TITLE
feat: use datastore directly for state store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,7 +124,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/boxo v0.27.4 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
-	github.com/ipfs/go-datastore v0.8.2 // indirect
+	github.com/ipfs/go-datastore v0.8.2
 	github.com/ipfs/go-ds-badger4 v0.1.8 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-kit/kit v0.13.0
 	github.com/gorilla/rpc v1.2.1
 	github.com/hashicorp/go-metrics v0.5.4
+	github.com/ipfs/go-datastore v0.8.2
 	github.com/rollkit/rollkit v0.14.2-0.20250422111549-9f2f92ea5c6e
 	github.com/rollkit/rollkit/core v0.0.0-20250422111549-9f2f92ea5c6e
 	github.com/rollkit/rollkit/da v0.0.0-20250422111549-9f2f92ea5c6e
@@ -128,7 +129,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/boxo v0.27.4 // indirect
 	github.com/ipfs/go-cid v0.5.0 // indirect
-	github.com/ipfs/go-datastore v0.8.2
 	github.com/ipfs/go-ds-badger4 v0.1.8 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -72,11 +72,13 @@ func NewABCIExecutor(
 		metrics = NopMetrics()
 	}
 
-	rollkitStore := rstore.New(store)
+	// Create a prefixed store for ABCI data
+	prefixedStore := NewPrefixedStore(store)
+	rollkitStore := rstore.New(store) // do not use prefixedStore for Rollkit
 
 	a := &Adapter{
 		App:          app,
-		Store:        store,
+		Store:        prefixedStore,
 		RollkitStore: rollkitStore,
 		Logger:       logger,
 		P2PClient:    p2pClient,

--- a/pkg/adapter/store.go
+++ b/pkg/adapter/store.go
@@ -8,9 +8,22 @@ import (
 	cmtstate "github.com/cometbft/cometbft/state"
 	proto "github.com/cosmos/gogoproto/proto"
 	ds "github.com/ipfs/go-datastore"
+	kt "github.com/ipfs/go-datastore/keytransform"
 )
 
-const stateKey = "abci-s"
+const (
+	// KeyPrefix is the prefix used for all ABCI-related keys in the datastore
+	KeyPrefix = "abci"
+	// stateKey is the key used for storing state
+	stateKey = "s"
+)
+
+// NewPrefixedStore creates a new datastore with the ABCI prefix
+func NewPrefixedStore(store ds.Batching) ds.Batching {
+	return kt.Wrap(store, &kt.PrefixTransform{
+		Prefix: ds.NewKey(KeyPrefix),
+	})
+}
 
 // loadState loads the state from disk
 func loadState(ctx context.Context, s ds.Batching) (*cmtstate.State, error) {

--- a/pkg/adapter/store.go
+++ b/pkg/adapter/store.go
@@ -7,15 +7,14 @@ import (
 	cmtstateproto "github.com/cometbft/cometbft/proto/tendermint/state"
 	cmtstate "github.com/cometbft/cometbft/state"
 	proto "github.com/cosmos/gogoproto/proto"
-
-	"github.com/rollkit/rollkit/pkg/store"
+	ds "github.com/ipfs/go-datastore"
 )
 
 const stateKey = "abci-s"
 
 // loadState loads the state from disk
-func loadState(ctx context.Context, s store.Store) (*cmtstate.State, error) {
-	data, err := s.GetMetadata(ctx, stateKey)
+func loadState(ctx context.Context, s ds.Batching) (*cmtstate.State, error) {
+	data, err := s.Get(ctx, ds.NewKey(stateKey))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get state metadata: %w", err)
 	}
@@ -32,7 +31,7 @@ func loadState(ctx context.Context, s store.Store) (*cmtstate.State, error) {
 }
 
 // saveState saves the state to disk
-func saveState(ctx context.Context, s store.Store, state *cmtstate.State) error {
+func saveState(ctx context.Context, s ds.Batching, state *cmtstate.State) error {
 	stateProto, err := state.ToProto()
 	if err != nil {
 		return fmt.Errorf("failed to convert state to proto: %w", err)
@@ -43,5 +42,5 @@ func saveState(ctx context.Context, s store.Store, state *cmtstate.State) error 
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
-	return s.SetMetadata(ctx, stateKey, data)
+	return s.Put(ctx, ds.NewKey(stateKey), data)
 }

--- a/pkg/rpc/provider/blockchain.go
+++ b/pkg/rpc/provider/blockchain.go
@@ -307,7 +307,7 @@ func (p *RpcProvider) Validators(ctx context.Context, heightPtr *int64, pagePtr 
 	// depending on state pruning. The current implementation implicitly loads latest state.
 	height := p.normalizeHeight(heightPtr)
 
-	s, err := p.adapter.LoadState(ctx) // Loads the *latest* state
+	s, err := p.adapter.Store.LoadState(ctx) // Loads the *latest* state
 	if err != nil {
 		return nil, fmt.Errorf("failed to load current state: %w", err)
 	}

--- a/pkg/rpc/provider/blockchain.go
+++ b/pkg/rpc/provider/blockchain.go
@@ -41,7 +41,7 @@ func (p *RpcProvider) Block(ctx context.Context, height *int64) (*coretypes.Resu
 	default:
 		heightValue = p.normalizeHeight(height)
 	}
-	header, data, err := p.adapter.Store.GetBlockData(ctx, heightValue)
+	header, data, err := p.adapter.RollkitStore.GetBlockData(ctx, heightValue)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (p *RpcProvider) Block(ctx context.Context, height *int64) (*coretypes.Resu
 
 // BlockByHash implements client.CometRPC.
 func (p *RpcProvider) BlockByHash(ctx context.Context, hash []byte) (*coretypes.ResultBlock, error) {
-	header, data, err := p.adapter.Store.GetBlockByHash(ctx, rlktypes.Hash(hash)) // Used types.Hash from rollkit/types
+	header, data, err := p.adapter.RollkitStore.GetBlockByHash(ctx, rlktypes.Hash(hash)) // Used types.Hash from rollkit/types
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (p *RpcProvider) BlockResults(ctx context.Context, height *int64) (*coretyp
 // Commit implements client.CometRPC.
 func (p *RpcProvider) Commit(ctx context.Context, height *int64) (*coretypes.ResultCommit, error) {
 	heightValue := p.normalizeHeight(height)
-	header, data, err := p.adapter.Store.GetBlockData(ctx, heightValue)
+	header, data, err := p.adapter.RollkitStore.GetBlockData(ctx, heightValue)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (p *RpcProvider) HeaderByHash(ctx context.Context, hash cmtbytes.HexBytes) 
 	// decoding logic in the HTTP service will correctly translate from JSON.
 	// See https://github.com/cometbft/cometbft/issues/6802 for context.
 
-	header, data, err := p.adapter.Store.GetBlockByHash(ctx, rlktypes.Hash(hash)) // Used types.Hash from rollkit/types
+	header, data, err := p.adapter.RollkitStore.GetBlockByHash(ctx, rlktypes.Hash(hash)) // Used types.Hash from rollkit/types
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (p *RpcProvider) HeaderByHash(ctx context.Context, hash cmtbytes.HexBytes) 
 func (p *RpcProvider) BlockchainInfo(ctx context.Context, minHeight int64, maxHeight int64) (*coretypes.ResultBlockchainInfo, error) {
 	const limit int64 = 20 // Default limit used in the original code
 
-	height, err := p.adapter.Store.Height(ctx)
+	height, err := p.adapter.RollkitStore.Height(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current height: %w", err)
 	}
@@ -211,7 +211,7 @@ func (p *RpcProvider) BlockchainInfo(ctx context.Context, minHeight int64, maxHe
 
 	// Re-fetch height in case new blocks were added during the loop?
 	// The original code did this.
-	finalHeight, err := p.adapter.Store.Height(ctx)
+	finalHeight, err := p.adapter.RollkitStore.Height(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get final height: %w", err)
 	}
@@ -274,7 +274,7 @@ func (p *RpcProvider) BlockSearch(ctx context.Context, query string, pagePtr *in
 	apiResults := make([]*coretypes.ResultBlock, 0, pageSize)
 	for i := skipCount; i < skipCount+pageSize; i++ {
 		height := uint64(results[i])
-		header, data, err := p.adapter.Store.GetBlockData(ctx, height)
+		header, data, err := p.adapter.RollkitStore.GetBlockData(ctx, height)
 		if err != nil {
 			// If a block referenced by indexer is missing, should we error out or just skip?
 			// For now, error out.

--- a/pkg/rpc/provider/info.go
+++ b/pkg/rpc/provider/info.go
@@ -17,7 +17,7 @@ func (p *RpcProvider) Status(ctx context.Context) (*coretypes.ResultStatus, erro
 		return nil, err
 	}
 
-	s, err := p.adapter.LoadState(ctx)
+	s, err := p.adapter.Store.LoadState(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (p *RpcProvider) Health(context.Context) (*coretypes.ResultHealth, error) {
 
 // ConsensusParams implements client.Client.
 func (p *RpcProvider) ConsensusParams(ctx context.Context, height *int64) (*coretypes.ResultConsensusParams, error) {
-	state, err := p.adapter.LoadState(ctx)
+	state, err := p.adapter.Store.LoadState(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/provider/provider.go
+++ b/pkg/rpc/provider/provider.go
@@ -50,7 +50,7 @@ func (p *RpcProvider) normalizeHeight(height *int64) uint64 {
 	if height == nil {
 		var err error
 		// TODO: Decide how to handle context here. Using background for now.
-		heightValue, err = p.adapter.Store.Height(context.Background())
+		heightValue, err = p.adapter.RollkitStore.Height(context.Background())
 		if err != nil {
 			// TODO: Consider logging or returning error
 			p.logger.Error("Failed to get current height in normalizeHeight", "err", err)
@@ -61,7 +61,7 @@ func (p *RpcProvider) normalizeHeight(height *int64) uint64 {
 		// Currently, just treat them as 0 or latest, adjust as needed.
 		// For now, let's assume negative height means latest valid height.
 		var err error
-		heightValue, err = p.adapter.Store.Height(context.Background())
+		heightValue, err = p.adapter.RollkitStore.Height(context.Background())
 		if err != nil {
 			p.logger.Error("Failed to get current height for negative height in normalizeHeight", "err", err)
 			return 0
@@ -74,7 +74,7 @@ func (p *RpcProvider) normalizeHeight(height *int64) uint64 {
 }
 
 func (p *RpcProvider) getBlockMeta(ctx context.Context, n uint64) *cmtypes.BlockMeta {
-	header, data, err := p.adapter.Store.GetBlockData(ctx, n)
+	header, data, err := p.adapter.RollkitStore.GetBlockData(ctx, n)
 	if err != nil {
 		p.logger.Error("Failed to get block data in getBlockMeta", "height", n, "err", err)
 		return nil

--- a/server/start.go
+++ b/server/start.go
@@ -329,11 +329,9 @@ func startNode(
 		adapterMetrics = adapter.PrometheusMetrics(config.DefaultInstrumentationConfig().Namespace, "chain_id", cmtGenDoc.ChainID)
 	}
 
-	st := store.New(database)
-
 	executor := adapter.NewABCIExecutor(
 		app,
-		st,
+		database,
 		p2pClient,
 		p2pMetrics,
 		logger,
@@ -350,7 +348,7 @@ func startNode(
 		panic(err)
 	}
 
-	height, err := st.Height(context.Background())
+	height, err := executor.RollkitStore.Height(context.Background())
 	if err != nil {
 		return nil, nil, cleanupFn, err
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Now we use datastore.Batching directly and create the rollkit interface internally in order to access Rollkit's data.

Closes #64

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated internal data storage to use a new datastore interface, improving separation between different storage mechanisms.
	- Enhanced block and blockchain data retrieval by switching to a dedicated store interface for improved consistency.
	- Streamlined state management with a new store wrapper, optimizing state loading and saving processes.
	- Simplified initialization by passing existing datastore instances directly, improving startup efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->