### PR TITLE
feat: Add Block and TX indexers

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -149,13 +149,13 @@ jobs:
           sleep 3
 
           # query the transaction (TODO: uncomment after tx indexer is fixed)
-          #TX_RESULT=$(gmd query tx $TX_HASH --output json)
-          #TX_CODE=$(echo $TX_RESULT | jq -r '.code')
-          #if [ "$TX_CODE" != "0" ]; then
-          #  echo "Error: Transaction failed with code $TX_CODE"
-          #  echo $TX_RESULT | jq
-          #  exit 1
-          #fi
+          TX_RESULT=$(gmd query tx $TX_HASH --output json)
+          TX_CODE=$(echo $TX_RESULT | jq -r '.code')
+          if [ "$TX_CODE" != "0" ]; then
+            echo "Error: Transaction failed with code $TX_CODE"
+            echo $TX_RESULT | jq
+            exit 1
+          fi
 
           # query bob's balance after transaction
           FINAL_BALANCE=$(gmd query bank balances $BOB_ADDRESS --output json | jq '.balances[0].amount' -r)

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -1,0 +1,207 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
+	cmtquery "github.com/cometbft/cometbft/libs/pubsub/query"
+	"github.com/cometbft/cometbft/mempool"
+	cmtypes "github.com/cometbft/cometbft/types"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	ds "github.com/ipfs/go-datastore"
+	kt "github.com/ipfs/go-datastore/keytransform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rollnode "github.com/rollkit/rollkit/node"
+	rstore "github.com/rollkit/rollkit/pkg/store"
+)
+
+func TestExecuteFiresEvents(t *testing.T) {
+	timestamp := time.Now()
+	myTxs := [][]byte{{0x01}, {0x02}}
+	myExecResult := []*abci.ExecTxResult{{Code: 0, Data: []byte{0}}, {Code: 0, Data: []byte{1}}}
+	specs := map[string]struct {
+		txs         [][]byte
+		mockMutator func(*MockABCIApp)
+		expErr      bool
+	}{
+		"all good - events published": {
+			txs:         myTxs,
+			mockMutator: func(*MockABCIApp) {},
+		},
+		"proposal fails - no events": {
+			txs: myTxs,
+			mockMutator: func(m *MockABCIApp) {
+				m.ProcessProposalFn = func(proposal *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+					return nil, errors.New("test")
+				}
+			},
+			expErr: true,
+		},
+		"finalize fails - no events": {
+			txs: myTxs,
+			mockMutator: func(m *MockABCIApp) {
+				m.FinalizeBlockFn = func(block *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+					return nil, errors.New("test")
+				}
+			},
+			expErr: true,
+		},
+		"commit fails - no events": {
+			txs: myTxs,
+			mockMutator: func(m *MockABCIApp) {
+				m.CommitFn = func() (*abci.ResponseCommit, error) {
+					return nil, errors.New("test")
+				}
+			},
+			expErr: true,
+		},
+	}
+	for name, spec := range specs {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+			eventBus := cmtypes.NewEventBus()
+			require.NoError(t, eventBus.Start())
+			t.Cleanup(func() { _ = eventBus.Stop() })
+
+			capturedBlockEvents, blockMx := captureEvents(ctx, eventBus, "tm.event='NewBlock'", 1)
+			capturedTxEvents, txMx := captureEvents(ctx, eventBus, "tm.event='Tx'", 2)
+			mockApp := &MockABCIApp{
+				ProcessProposalFn: func(proposal *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+					return &abci.ResponseProcessProposal{Status: abci.ResponseProcessProposal_ACCEPT}, nil
+				},
+				FinalizeBlockFn: func(block *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+					return &abci.ResponseFinalizeBlock{
+						TxResults: myExecResult,
+					}, nil
+				},
+				CommitFn: func() (*abci.ResponseCommit, error) {
+					return &abci.ResponseCommit{}, nil
+				},
+			}
+			spec.mockMutator(mockApp)
+
+			originStore := ds.NewMapDatastore()
+			rollkitPrefixStore := kt.Wrap(originStore, &kt.PrefixTransform{
+				Prefix: ds.NewKey(rollnode.RollkitPrefix),
+			})
+			rollkitStore := rstore.New(rollkitPrefixStore)
+			abciStore := NewStore(originStore)
+			adapter := &Adapter{
+				App:          mockApp,
+				Store:        abciStore,
+				RollkitStore: rollkitStore,
+				EventBus:     eventBus,
+				Metrics:      NopMetrics(),
+				Logger:       log.NewTestLogger(t),
+				MempoolIDs:   newMempoolIDs(),
+				Mempool:      &mempool.NopMempool{},
+			}
+			require.NoError(t, adapter.Store.SaveState(ctx, stateFixture()))
+
+			// when
+			_, _, err := adapter.ExecuteTxs(ctx, spec.txs, 1, timestamp, bytes.Repeat([]byte{1}, 32))
+			if spec.expErr {
+				require.Error(t, err)
+				blockMx.RLock()
+				defer blockMx.RUnlock()
+				require.Empty(t, *capturedBlockEvents)
+				require.Empty(t, *capturedTxEvents)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Eventually(t, func() bool {
+				blockMx.RLock()
+				defer blockMx.RUnlock()
+				return len(*capturedBlockEvents) == 1
+			}, time.Second, 20*time.Millisecond)
+			assert.Eventually(t, func() bool {
+				txMx.RLock()
+				defer txMx.RUnlock()
+				return len(*capturedTxEvents) == 2
+			}, time.Second, 20*time.Millisecond)
+			cancel()
+
+			blockMx.RLock()
+			t.Cleanup(blockMx.RUnlock)
+			gotMsg := (*capturedBlockEvents)[0].Data().(cmtypes.EventDataNewBlock)
+			expAbciResult := abci.ResponseFinalizeBlock{
+				TxResults: myExecResult,
+			}
+			assert.Equal(t, expAbciResult, gotMsg.ResultFinalizeBlock)
+
+			txMx.RLock()
+			t.Cleanup(txMx.RUnlock)
+			for i, v := range *capturedTxEvents {
+				event := v.Data().(cmtypes.EventDataTx)
+				assert.Equal(t, *expAbciResult.TxResults[i], event.Result)
+				assert.Equal(t, spec.txs[i], event.Tx)
+				assert.Equal(t, uint32(i), event.Index)
+				assert.Equal(t, int64(1), event.Height)
+			}
+		})
+	}
+}
+
+func captureEvents(ctx context.Context, eventBus *cmtypes.EventBus, query string, numEventsExpected int) (*[]cmtpubsub.Message, *sync.RWMutex) {
+	evSub, err := eventBus.Subscribe(ctx, "test", cmtquery.MustCompile(query), numEventsExpected)
+	if err != nil {
+		panic(err)
+	}
+	var mx sync.RWMutex
+	capturedEvents := make([]cmtpubsub.Message, 0, numEventsExpected)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case v := <-evSub.Out():
+				mx.Lock()
+				capturedEvents = append(capturedEvents, v)
+				if len(capturedEvents) >= numEventsExpected {
+					mx.Unlock()
+					return
+				}
+				mx.Unlock()
+			}
+		}
+	}()
+	return &capturedEvents, &mx
+}
+
+type MockABCIApp struct {
+	servertypes.ABCI  // satisfy the interface
+	ProcessProposalFn func(*abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error)
+	FinalizeBlockFn   func(*abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error)
+	CommitFn          func() (*abci.ResponseCommit, error)
+}
+
+func (m *MockABCIApp) ProcessProposal(r *abci.RequestProcessProposal) (*abci.ResponseProcessProposal, error) {
+	if m.ProcessProposalFn == nil {
+		panic("not expected to be called")
+	}
+	return m.ProcessProposalFn(r)
+}
+func (m *MockABCIApp) FinalizeBlock(r *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
+	if m.FinalizeBlockFn == nil {
+		panic("not expected to be called")
+	}
+	return m.FinalizeBlockFn(r)
+}
+
+func (m *MockABCIApp) Commit() (*abci.ResponseCommit, error) {
+	if m.CommitFn == nil {
+		panic("not expected to be called")
+	}
+	return m.CommitFn()
+}

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -154,7 +155,8 @@ func TestExecuteFiresEvents(t *testing.T) {
 }
 
 func captureEvents(ctx context.Context, eventBus *cmtypes.EventBus, query string, numEventsExpected int) (*[]cmtpubsub.Message, *sync.RWMutex) {
-	evSub, err := eventBus.Subscribe(ctx, "test", cmtquery.MustCompile(query), numEventsExpected)
+	subscriber := fmt.Sprintf("test-%d", time.Now().UnixNano())
+	evSub, err := eventBus.Subscribe(ctx, subscriber, cmtquery.MustCompile(query), numEventsExpected)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/rpc/core/const.go
+++ b/pkg/rpc/core/const.go
@@ -1,5 +1,7 @@
 package core
 
+import "time"
+
 const (
 	// maxQueryLength is the maximum length of a query string that will be
 	// accepted. This is just a safety check to avoid outlandish queries.
@@ -7,4 +9,8 @@ const (
 
 	defaultPerPage = 30
 	maxPerPage     = 100
+
+	// SubscribeTimeout is the maximum time we wait to subscribe for an event.
+	// must be less than the server's write timeout (see rpcserver.DefaultConfig)
+	SubscribeTimeout = 5 * time.Second
 )

--- a/pkg/rpc/core/env.go
+++ b/pkg/rpc/core/env.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
 	cmtlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/state/indexer"
 	"github.com/cometbft/cometbft/state/txindex"
@@ -28,6 +29,7 @@ type Environment struct {
 	TxIndexer    txindex.TxIndexer
 	BlockIndexer indexer.BlockIndexer
 	Logger       cmtlog.Logger
+	Config       cmtcfg.RPCConfig
 }
 
 func validateSkipCount(page, perPage int) int {

--- a/pkg/rpc/core/events.go
+++ b/pkg/rpc/core/events.go
@@ -1,8 +1,13 @@
 package core
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"time"
 
+	cmtpubsub "github.com/cometbft/cometbft/libs/pubsub"
+	cmtquery "github.com/cometbft/cometbft/libs/pubsub/query"
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 )
@@ -10,54 +15,111 @@ import (
 // Subscribe for events via WebSocket.
 // More: https://docs.cometbft.com/v0.37/rpc/#/Websocket/subscribe
 func Subscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultSubscribe, error) {
-	// Check if EventBus is available
-	if env.Adapter.EventBus == nil {
-		return nil, errors.New("event bus is not configured, cannot subscribe to events")
+	{
+		addr := ctx.RemoteAddr()
+
+		if env.Adapter.EventBus.NumClients() >= env.Config.MaxSubscriptionClients {
+			return nil, fmt.Errorf("max_subscription_clients %d reached", env.Config.MaxSubscriptionClients)
+		} else if env.Adapter.EventBus.NumClientSubscriptions(addr) >= env.Config.MaxSubscriptionsPerClient {
+			return nil, fmt.Errorf("max_subscriptions_per_client %d reached", env.Config.MaxSubscriptionsPerClient)
+		} else if len(query) > maxQueryLength {
+			return nil, errors.New("maximum query length exceeded")
+		}
+
+		env.Logger.Info("Subscribe to query", "remote", addr, "query", query)
+
+		q, err := cmtquery.New(query)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse query: %w", err)
+		}
+
+		subCtx, cancel := context.WithTimeout(ctx.Context(), SubscribeTimeout)
+		defer cancel()
+
+		sub, err := env.Adapter.EventBus.Subscribe(subCtx, addr, q, env.Config.SubscriptionBufferSize)
+		if err != nil {
+			return nil, err
+		}
+
+		closeIfSlow := env.Config.CloseOnSlowClient
+
+		// Capture the current ID, since it can change in the future.
+		subscriptionID := ctx.JSONReq.ID
+		go func() {
+			for {
+				select {
+				case msg := <-sub.Out():
+					var (
+						resultEvent = &ctypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}
+						resp        = rpctypes.NewRPCSuccessResponse(subscriptionID, resultEvent)
+					)
+					writeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+					defer cancel()
+					if err := ctx.WSConn.WriteRPCResponse(writeCtx, resp); err != nil {
+						env.Logger.Info("Can't write response (slow client)",
+							"to", addr, "subscriptionID", subscriptionID, "err", err)
+
+						if closeIfSlow {
+							var (
+								err  = errors.New("subscription was canceled (reason: slow client)")
+								resp = rpctypes.RPCServerError(subscriptionID, err)
+							)
+							if !ctx.WSConn.TryWriteRPCResponse(resp) {
+								env.Logger.Info("Can't write response (slow client)",
+									"to", addr, "subscriptionID", subscriptionID, "err", err)
+							}
+							return
+						}
+					}
+				case <-sub.Canceled():
+					if sub.Err() != cmtpubsub.ErrUnsubscribed {
+						var reason string
+						if sub.Err() == nil {
+							reason = "CometBFT exited"
+						} else {
+							reason = sub.Err().Error()
+						}
+						var (
+							err  = fmt.Errorf("subscription was canceled (reason: %s)", reason)
+							resp = rpctypes.RPCServerError(subscriptionID, err)
+						)
+						if !ctx.WSConn.TryWriteRPCResponse(resp) {
+							env.Logger.Info("Can't write response (slow client)",
+								"to", addr, "subscriptionID", subscriptionID, "err", err)
+						}
+					}
+					return
+				}
+			}
+		}()
+
+		return &ctypes.ResultSubscribe{}, nil
 	}
-	// TODO: Implement subscription logic using p.adapter.EventBus
-	// Example structure (needs actual implementation):
-	// q, err := cmtquery.New(query)
-	// if err != nil {
-	// 	 return nil, fmt.Errorf("failed to parse query: %w", err)
-	// }
-	// sub, err := p.adapter.EventBus.Subscribe(ctx, subscriber, q, outCapacity...)
-	// if err != nil {
-	// 	  return nil, fmt.Errorf("failed to subscribe: %w", err)
-	// }
-	// // Need a way to convert EventBus messages to coretypes.ResultEvent
-	// outChan := make(chan coretypes.ResultEvent, ...) // Use appropriate capacity
-	// go func() {
-	// 	  for msg := range sub.Out() {
-	// 		  // Conversion logic here
-	// 		  outChan <- coretypes.ResultEvent{Query: query, Data: msg.Data(), Events: msg.Events()}
-	// 	  }
-	// 	  close(outChan)
-	// }()
-	// return outChan, nil
-	return nil, errors.New("event subscription functionality is not yet implemented")
 }
 
 // Unsubscribe from events via WebSocket.
 // More: https://docs.cometbft.com/v0.37/rpc/#/Websocket/unsubscribe
 func Unsubscribe(ctx *rpctypes.Context, query string) (*ctypes.ResultUnsubscribe, error) {
-	if env.Adapter.EventBus == nil {
-		return nil, errors.New("event bus is not configured, cannot unsubscribe")
+	addr := ctx.RemoteAddr()
+	env.Logger.Info("Unsubscribe from query", "remote", addr, "query", query)
+	q, err := cmtquery.New(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
 	}
-	// TODO: Implement unsubscription logic using p.adapter.EventBus
-	// Example structure:
-	// q, err := cmtquery.New(query)
-	// if err != nil {
-	// 	 return fmt.Errorf("failed to parse query: %w", err)
-	// }
-	// return p.adapter.EventBus.Unsubscribe(ctx, subscriber, q)
-	return nil, errors.New("event unsubscription functionality is not yet implemented")
+	err = env.Adapter.EventBus.Unsubscribe(context.Background(), addr, q)
+	if err != nil {
+		return nil, err
+	}
+	return &ctypes.ResultUnsubscribe{}, nil
+
 }
 
 func UnsubscribeAll(ctx *rpctypes.Context) (*ctypes.ResultUnsubscribe, error) {
-	if env.Adapter.EventBus == nil {
-		return nil, errors.New("event bus is not configured, cannot unsubscribe")
+	addr := ctx.RemoteAddr()
+	env.Logger.Info("Unsubscribe from all", "remote", addr)
+	err := env.Adapter.EventBus.UnsubscribeAll(context.Background(), addr)
+	if err != nil {
+		return nil, err
 	}
-	// TODO: Implement unsubscribe all logic using p.adapter.EventBus
-	// return p.adapter.EventBus.UnsubscribeAll(ctx, subscriber)
-	return nil, errors.New("event unsubscribe all functionality is not yet implemented")
+	return &ctypes.ResultUnsubscribe{}, nil
 }

--- a/pkg/rpc/core/mempool.go
+++ b/pkg/rpc/core/mempool.go
@@ -129,9 +129,9 @@ func BroadcastTxCommit(ctx *rpctypes.Context, tx cmttypes.Tx) (*ctypes.ResultBro
 
 	// Use CometBFT config values directly if available
 	// TODO: Access these config values properly, perhaps via RpcProvider struct if needed
-	maxSubs := 100                                                     // Placeholder
-	maxClients := 100                                                  // Placeholder
-	commitTimeout := env.Adapter.CometCfg.RPC.TimeoutBroadcastTxCommit // Assuming CometCfg is accessible
+	maxSubs := 100                                       // Placeholder
+	maxClients := 100                                    // Placeholder
+	commitTimeout := env.Config.TimeoutBroadcastTxCommit // Assuming CometCfg is accessible
 
 	if env.Adapter.EventBus.NumClients() >= maxClients {
 		return nil, fmt.Errorf("max_subscription_clients %d reached", maxClients)

--- a/pkg/rpc/core/tx.go
+++ b/pkg/rpc/core/tx.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 
@@ -48,7 +47,7 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 			// Assuming blockRes.Block.Data.Txs implements some `Proof(index)` method
 			proof = blockRes.Block.Data.Txs.Proof(int(txResult.Index))
 		*/
-		return nil, errors.New("transaction proof generation is not supported") // Return error as proofs aren't supported
+		//return nil, errors.New("transaction proof generation is not supported") // Return error as proofs aren't supported
 		// block := env.BlockStore.LoadBlock(r.Height)
 		// proof = block.Data.Txs.Proof(int(r.Index))
 	}
@@ -137,7 +136,7 @@ func TxSearch(
 		var proof types.TxProof
 		if prove {
 			// Proof generation is currently not supported.
-			return nil, errors.New("transaction proof generation is not supported")
+			//return nil, errors.New("transaction proof generation is not supported")
 		}
 
 		apiResults = append(apiResults, &ctypes.ResultTx{

--- a/pkg/rpc/core/tx.go
+++ b/pkg/rpc/core/tx.go
@@ -32,25 +32,25 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 	}
 
 	var proof types.TxProof
-	if prove {
-		// Proof generation is currently not supported.
-		// When supported, logic to retrieve block and compute proof would go here.
-		// Example (requires block fetching and a Prove method on block.Data.Txs):
-		/*
-			blockRes, err := p.Block(ctx, &txResult.Height)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get block %d for proof: %w", txResult.Height, err)
-			}
-			if blockRes == nil || blockRes.Block == nil {
-				return nil, fmt.Errorf("block %d not found for proof", txResult.Height)
-			}
-			// Assuming blockRes.Block.Data.Txs implements some `Proof(index)` method
-			proof = blockRes.Block.Data.Txs.Proof(int(txResult.Index))
-		*/
-		//return nil, errors.New("transaction proof generation is not supported") // Return error as proofs aren't supported
-		// block := env.BlockStore.LoadBlock(r.Height)
-		// proof = block.Data.Txs.Proof(int(r.Index))
-	}
+	//if prove {
+	// Proof generation is currently not supported.
+	// When supported, logic to retrieve block and compute proof would go here.
+	// Example (requires block fetching and a Prove method on block.Data.Txs):
+	/*
+		blockRes, err := p.Block(ctx, &txResult.Height)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get block %d for proof: %w", txResult.Height, err)
+		}
+		if blockRes == nil || blockRes.Block == nil {
+			return nil, fmt.Errorf("block %d not found for proof", txResult.Height)
+		}
+		// Assuming blockRes.Block.Data.Txs implements some `Proof(index)` method
+		proof = blockRes.Block.Data.Txs.Proof(int(txResult.Index))
+	*/
+	//return nil, errors.New("transaction proof generation is not supported") // Return error as proofs aren't supported
+	// block := env.BlockStore.LoadBlock(r.Height)
+	// proof = block.Data.Txs.Proof(int(r.Index))
+	//}
 
 	return &ctypes.ResultTx{
 		Hash:     hash,
@@ -134,10 +134,10 @@ func TxSearch(
 	for i := skipCount; i < skipCount+pageSize; i++ {
 		result := txResults[i]
 		var proof types.TxProof
-		if prove {
-			// Proof generation is currently not supported.
-			//return nil, errors.New("transaction proof generation is not supported")
-		}
+		//if prove {
+		// Proof generation is currently not supported.
+		//return nil, errors.New("transaction proof generation is not supported")
+		//}
 
 		apiResults = append(apiResults, &ctypes.ResultTx{
 			Hash:     types.Tx(result.Tx).Hash(), // Correctly calculate hash from []byte

--- a/server/start.go
+++ b/server/start.go
@@ -14,6 +14,10 @@ import (
 	cmtp2p "github.com/cometbft/cometbft/p2p"
 	pvm "github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/proxy"
+	"github.com/cometbft/cometbft/state/indexer"
+	"github.com/cometbft/cometbft/state/indexer/block"
+	"github.com/cometbft/cometbft/state/txindex"
+	cmttypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -443,10 +447,22 @@ func setupNodeAndExecutor(
 	if err != nil {
 		return nil, nil, cleanupFn, err
 	}
+	eventBus, err := createAndStartEventBus(logger)
+	if err != nil {
+		return nil, nil, cleanupFn, fmt.Errorf("setup event-bus: %w", err)
+	}
+	executor.EventBus = eventBus
 
+	idxSvc, txIndexer, blockIndexer, err := createAndStartIndexerService(cfg, cmtGenDoc.ChainID, cmtcfg.DefaultDBProvider, eventBus, logger)
+	if err != nil {
+		return nil, nil, cleanupFn, fmt.Errorf("start indexer service: %w", err)
+	}
 	core.SetEnvironment(&core.Environment{
-		Logger:  servercmtlog.CometLoggerWrapper{Logger: logger},
-		Adapter: executor,
+		Adapter:      executor,
+		TxIndexer:    txIndexer,
+		BlockIndexer: blockIndexer,
+		Logger:       servercmtlog.CometLoggerWrapper{Logger: logger},
+		Config:       *cfg.RPC,
 	})
 
 	// Pass the created handler to the RPC server constructor
@@ -455,8 +471,55 @@ func setupNodeAndExecutor(
 	if err != nil {
 		return nil, nil, cleanupFn, fmt.Errorf("failed to start rpc server: %w", err)
 	}
-
+	cleanupFn = func() {
+		cancelFn()
+		_ = eventBus.Stop()
+		_ = idxSvc.Stop()
+		_ = rpcServer.Stop()
+	}
 	return rolllkitNode, executor, cleanupFn, nil
+}
+
+func createAndStartEventBus(logger log.Logger) (*cmttypes.EventBus, error) {
+	eventBus := cmttypes.NewEventBus()
+	eventBus.SetLogger(servercmtlog.CometLoggerWrapper{Logger: logger}.With("module", "events"))
+	if err := eventBus.Start(); err != nil {
+		return nil, err
+	}
+	return eventBus, nil
+}
+
+func createAndStartIndexerService(
+	config *cmtcfg.Config,
+	chainID string,
+	dbProvider cmtcfg.DBProvider,
+	eventBus *cmttypes.EventBus,
+	logger log.Logger,
+) (*txindex.IndexerService, txindex.TxIndexer, indexer.BlockIndexer, error) {
+	var (
+		txIndexer    txindex.TxIndexer
+		blockIndexer indexer.BlockIndexer
+	)
+
+	txIndexer, blockIndexer, allIndexersDisabled, err := block.IndexerFromConfigWithDisabledIndexers(config, dbProvider, chainID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if allIndexersDisabled {
+		return nil, txIndexer, blockIndexer, nil
+	}
+
+	cmtLogger := servercmtlog.CometLoggerWrapper{Logger: logger}.With("module", "txindex")
+	txIndexer.SetLogger(cmtLogger)
+	blockIndexer.SetLogger(cmtLogger)
+
+	indexerService := txindex.NewIndexerService(txIndexer, blockIndexer, eventBus, false)
+	indexerService.SetLogger(cmtLogger)
+	if err := indexerService.Start(); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return indexerService, txIndexer, blockIndexer, nil
 }
 
 // getGenDocProvider returns a function which returns the genesis doc from the genesis file.

--- a/server/start.go
+++ b/server/start.go
@@ -474,7 +474,9 @@ func setupNodeAndExecutor(
 	cleanupFn = func() {
 		cancelFn()
 		_ = eventBus.Stop()
-		_ = idxSvc.Stop()
+		if idxSvc != nil {
+			_ = idxSvc.Stop()
+		}
 		_ = rpcServer.Stop()
 	}
 	return rolllkitNode, executor, cleanupFn, nil


### PR DESCRIPTION
Resolves #28 

Build and test with a generated ignite app:

```sh
gmd query blocks --query "block.height > 0"
```
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added event subscription, unsubscription, and unsubscription-all capabilities via WebSocket, enabling clients to receive real-time updates.
  - Integrated event bus and indexing services for enhanced event handling and querying.
  - Introduced a 5-second timeout for event subscription requests.

- **Bug Fixes**
  - Restored error handling for transaction query failures in integration tests.

- **Improvements**
  - Enhanced event emission after block execution, including publishing block and transaction events.
  - Improved error handling and resource management in transaction execution.
  - Updated configuration references for transaction commit timeouts.

- **Tests**
  - Added comprehensive tests to verify event emission and error handling during transaction execution.

- **Other**
  - Updated environment and configuration structures to support new features and integrations.
  - Disabled transaction proof error responses, now silently ignoring unsupported proof requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->