### PR TITLE
chore: Use stored block data instead

### DIFF
--- a/pkg/common/convert.go
+++ b/pkg/common/convert.go
@@ -1,0 +1,112 @@
+package common
+
+import (
+	"errors"
+	"time"
+
+	cmbytes "github.com/cometbft/cometbft/libs/bytes"
+	cmversion "github.com/cometbft/cometbft/proto/tendermint/version"
+	cmttypes "github.com/cometbft/cometbft/types"
+
+	rlktypes "github.com/rollkit/rollkit/types"
+)
+
+// ToABCIHeader converts Rollkit header to Header format defined in ABCI.
+// Caller should fill all the fields that are not available in Rollkit header (like ChainID).
+func ToABCIHeader(header *rlktypes.Header) (cmttypes.Header, error) {
+	return cmttypes.Header{
+		Version: cmversion.Consensus{
+			Block: header.Version.Block,
+			App:   header.Version.App,
+		},
+		Height: int64(header.Height()), //nolint:gosec
+		Time:   header.Time(),
+		LastBlockID: cmttypes.BlockID{
+			Hash: cmbytes.HexBytes(header.LastHeaderHash[:]),
+			PartSetHeader: cmttypes.PartSetHeader{
+				Total: 0,
+				Hash:  nil,
+			},
+		},
+		LastCommitHash:     cmbytes.HexBytes(header.LastCommitHash),
+		DataHash:           cmbytes.HexBytes(header.DataHash),
+		ConsensusHash:      cmbytes.HexBytes(header.ConsensusHash),
+		AppHash:            cmbytes.HexBytes(header.AppHash),
+		LastResultsHash:    cmbytes.HexBytes(header.LastResultsHash),
+		EvidenceHash:       new(cmttypes.EvidenceData).Hash(),
+		ProposerAddress:    header.ProposerAddress,
+		ChainID:            header.ChainID(),
+		ValidatorsHash:     cmbytes.HexBytes(header.ValidatorHash),
+		NextValidatorsHash: cmbytes.HexBytes(header.ValidatorHash),
+	}, nil
+}
+
+// ToABCIBlock converts Rolkit block into block format defined by ABCI.
+// Returned block should pass `ValidateBasic`.
+func ToABCIBlock(header *rlktypes.SignedHeader, data *rlktypes.Data) (*cmttypes.Block, error) {
+	abciHeader, err := ToABCIHeader(&header.Header)
+	if err != nil {
+		return nil, err
+	}
+
+	// we have one validator
+	if len(header.ProposerAddress) == 0 {
+		return nil, errors.New("proposer address is not set")
+	}
+
+	abciCommit := ToABCICommit(header.Height(), header.Hash(), header.ProposerAddress, header.Time(), header.Signature)
+
+	// This assumes that we have only one signature
+	if len(abciCommit.Signatures) == 1 {
+		abciCommit.Signatures[0].ValidatorAddress = header.ProposerAddress
+	}
+	abciBlock := cmttypes.Block{
+		Header: abciHeader,
+		Evidence: cmttypes.EvidenceData{
+			Evidence: nil,
+		},
+		LastCommit: abciCommit,
+	}
+	abciBlock.Txs = make([]cmttypes.Tx, len(data.Txs))
+	for i := range data.Txs {
+		abciBlock.Txs[i] = cmttypes.Tx(data.Txs[i])
+	}
+	abciBlock.DataHash = cmbytes.HexBytes(header.DataHash)
+
+	return &abciBlock, nil
+}
+
+// ToABCIBlockMeta converts Rollkit block into BlockMeta format defined by ABCI
+func ToABCIBlockMeta(header *rlktypes.SignedHeader, data *rlktypes.Data) (*cmttypes.BlockMeta, error) {
+	cmblock, err := ToABCIBlock(header, data)
+	if err != nil {
+		return nil, err
+	}
+	blockID := cmttypes.BlockID{Hash: cmblock.Hash()}
+
+	return &cmttypes.BlockMeta{
+		BlockID:   blockID,
+		BlockSize: cmblock.Size(),
+		Header:    cmblock.Header,
+		NumTxs:    len(cmblock.Txs),
+	}, nil
+}
+
+// ToABCICommit returns a commit format defined by ABCI.
+// Other fields (especially ValidatorAddress and Timestamp of Signature) have to be filled by caller.
+func ToABCICommit(height uint64, hash rlktypes.Hash, val cmttypes.Address, time time.Time, signature rlktypes.Signature) *cmttypes.Commit {
+	return &cmttypes.Commit{
+		Height: int64(height), //nolint:gosec
+		Round:  0,
+		BlockID: cmttypes.BlockID{
+			Hash:          cmbytes.HexBytes(hash),
+			PartSetHeader: cmttypes.PartSetHeader{},
+		},
+		Signatures: []cmttypes.CommitSig{{
+			BlockIDFlag:      cmttypes.BlockIDFlagCommit,
+			Signature:        signature,
+			ValidatorAddress: val,
+			Timestamp:        time,
+		}},
+	}
+}

--- a/pkg/rpc/core/blocks.go
+++ b/pkg/rpc/core/blocks.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/rollkit/rollkit/block"
 	rlktypes "github.com/rollkit/rollkit/types"
+
+	"github.com/rollkit/go-execution-abci/pkg/common"
 )
 
 // BlockSearch searches for a paginated set of blocks matching BeginBlock and
@@ -69,7 +71,7 @@ func BlockSearch(
 		if err != nil {
 			return nil, err
 		}
-		block, err := ToABCIBlock(header, data)
+		block, err := common.ToABCIBlock(header, data)
 		if err != nil {
 			return nil, err
 		}
@@ -114,7 +116,7 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 	}
 
 	hash := header.Hash()
-	abciBlock, err := ToABCIBlock(header, data)
+	abciBlock, err := common.ToABCIBlock(header, data)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +140,7 @@ func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error
 		return nil, err
 	}
 
-	abciBlock, err := ToABCIBlock(header, data)
+	abciBlock, err := common.ToABCIBlock(header, data)
 	if err != nil {
 		return nil, err
 	}
@@ -171,9 +173,9 @@ func Commit(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultCommit, erro
 	}
 
 	val := header.ProposerAddress
-	commit := GetABCICommit(heightValue, header.Hash(), val, header.Time(), header.Signature)
+	commit := common.ToABCICommit(heightValue, header.Hash(), val, header.Time(), header.Signature)
 
-	block, err := ToABCIBlock(header, data)
+	block, err := common.ToABCIBlock(header, data)
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +240,7 @@ func HeaderByHash(ctx *rpctypes.Context, hash cmbytes.HexBytes) (*ctypes.ResultH
 		return nil, err
 	}
 
-	blockMeta, err := ToABCIBlockMeta(header, data)
+	blockMeta, err := common.ToABCIBlockMeta(header, data)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +282,7 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 			return nil, err
 		}
 		if header != nil && data != nil {
-			cmblockmeta, err := ToABCIBlockMeta(header, data)
+			cmblockmeta, err := common.ToABCIBlockMeta(header, data)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/rpc/core/tx_test.go
+++ b/pkg/rpc/core/tx_test.go
@@ -239,11 +239,9 @@ func TestTxSearch(t *testing.T) {
 			require.NotNil(q)
 		}).Return(searchResults, nil).Once()
 		mockStore.On("GetBlockData", mock.Anything, uint64(res1.Height)).Return(nil,
-			&rktypes.Data{Txs: rktypes.Txs{[]byte{0}, []byte{1}}}, nil).Once()
+			&rktypes.Data{Txs: rktypes.Txs{[]byte{0}, []byte{1}}}, nil).Twice()
 		mockStore.On("GetBlockData", mock.Anything, uint64(res2.Height)).Return(nil,
 			&rktypes.Data{Txs: rktypes.Txs{[]byte{2}}}, nil).Once()
-		mockStore.On("GetBlockData", mock.Anything, uint64(res3.Height)).Return(nil,
-			&rktypes.Data{Txs: rktypes.Txs{[]byte{3}, []byte{4}, []byte{5}}}, nil).Once()
 
 		result, err := TxSearch(ctx, query, true, &defaultPage, &defaultPerPage, orderBy)
 
@@ -263,7 +261,7 @@ func TestTxSearch(t *testing.T) {
 		assert.Equal(int64(10), result.Txs[1].Height)
 		assert.Equal(uint32(1), result.Txs[1].Index)
 		assert.Equal(tx1.Hash(), []byte(result.Txs[1].Hash))
-		assert.Equal(int64(3), result.Txs[1].Proof.Proof.Total)
+		assert.Equal(int64(2), result.Txs[1].Proof.Proof.Total)
 		assert.Equal(int64(1), result.Txs[1].Proof.Proof.Index)
 		assert.NotEmpty(result.Txs[1].Proof.Proof.LeafHash)
 

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -5,120 +5,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"time"
-
-	cmbytes "github.com/cometbft/cometbft/libs/bytes"
-	cmversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	cmttypes "github.com/cometbft/cometbft/types"
-
-	rlktypes "github.com/rollkit/rollkit/types"
+	"github.com/rollkit/go-execution-abci/pkg/common"
 )
 
 const NodeIDByteLength = 20
-
-// ToABCIHeader converts Rollkit header to Header format defined in ABCI.
-// Caller should fill all the fields that are not available in Rollkit header (like ChainID).
-func ToABCIHeader(header *rlktypes.Header) (cmttypes.Header, error) {
-	return cmttypes.Header{
-		Version: cmversion.Consensus{
-			Block: header.Version.Block,
-			App:   header.Version.App,
-		},
-		Height: int64(header.Height()), //nolint:gosec
-		Time:   header.Time(),
-		LastBlockID: cmttypes.BlockID{
-			Hash: cmbytes.HexBytes(header.LastHeaderHash[:]),
-			PartSetHeader: cmttypes.PartSetHeader{
-				Total: 0,
-				Hash:  nil,
-			},
-		},
-		LastCommitHash:     cmbytes.HexBytes(header.LastCommitHash),
-		DataHash:           cmbytes.HexBytes(header.DataHash),
-		ConsensusHash:      cmbytes.HexBytes(header.ConsensusHash),
-		AppHash:            cmbytes.HexBytes(header.AppHash),
-		LastResultsHash:    cmbytes.HexBytes(header.LastResultsHash),
-		EvidenceHash:       new(cmttypes.EvidenceData).Hash(),
-		ProposerAddress:    header.ProposerAddress,
-		ChainID:            header.ChainID(),
-		ValidatorsHash:     cmbytes.HexBytes(header.ValidatorHash),
-		NextValidatorsHash: cmbytes.HexBytes(header.ValidatorHash),
-	}, nil
-}
-
-// ToABCIBlock converts Rolkit block into block format defined by ABCI.
-// Returned block should pass `ValidateBasic`.
-func ToABCIBlock(header *rlktypes.SignedHeader, data *rlktypes.Data) (*cmttypes.Block, error) {
-	abciHeader, err := ToABCIHeader(&header.Header)
-	if err != nil {
-		return nil, err
-	}
-
-	// we have one validator
-	if len(header.ProposerAddress) == 0 {
-		return nil, errors.New("proposer address is not set")
-	}
-
-	abciCommit := getABCICommit(header.Height(), header.Hash(), header.ProposerAddress, header.Time(), header.Signature)
-
-	// This assumes that we have only one signature
-	if len(abciCommit.Signatures) == 1 {
-		abciCommit.Signatures[0].ValidatorAddress = header.ProposerAddress
-	}
-	abciBlock := cmttypes.Block{
-		Header: abciHeader,
-		Evidence: cmttypes.EvidenceData{
-			Evidence: nil,
-		},
-		LastCommit: abciCommit,
-	}
-	abciBlock.Txs = make([]cmttypes.Tx, len(data.Txs))
-	for i := range data.Txs {
-		abciBlock.Txs[i] = cmttypes.Tx(data.Txs[i])
-	}
-	abciBlock.DataHash = cmbytes.HexBytes(header.DataHash)
-
-	return &abciBlock, nil
-}
-
-// ToABCIBlockMeta converts Rollkit block into BlockMeta format defined by ABCI
-func ToABCIBlockMeta(header *rlktypes.SignedHeader, data *rlktypes.Data) (*cmttypes.BlockMeta, error) {
-	cmblock, err := ToABCIBlock(header, data)
-	if err != nil {
-		return nil, err
-	}
-	blockID := cmttypes.BlockID{Hash: cmblock.Hash()}
-
-	return &cmttypes.BlockMeta{
-		BlockID:   blockID,
-		BlockSize: cmblock.Size(),
-		Header:    cmblock.Header,
-		NumTxs:    len(cmblock.Txs),
-	}, nil
-}
-
-// getABCICommit returns a commit format defined by ABCI.
-// Other fields (especially ValidatorAddress and Timestamp of Signature) have to be filled by caller.
-func getABCICommit(height uint64, hash []byte, val cmttypes.Address, time time.Time, signature []byte) *cmttypes.Commit {
-	tmCommit := cmttypes.Commit{
-		Height: int64(height), //nolint:gosec
-		Round:  0,
-		BlockID: cmttypes.BlockID{
-			Hash:          cmbytes.HexBytes(hash),
-			PartSetHeader: cmttypes.PartSetHeader{},
-		},
-		Signatures: make([]cmttypes.CommitSig, 1),
-	}
-	commitSig := cmttypes.CommitSig{
-		BlockIDFlag:      cmttypes.BlockIDFlagCommit,
-		Signature:        signature,
-		ValidatorAddress: val,
-		Timestamp:        time,
-	}
-	tmCommit.Signatures[0] = commitSig
-
-	return &tmCommit
-}
 
 func normalizeHeight(height *int64) uint64 {
 	var heightValue uint64
@@ -159,7 +50,7 @@ func getBlockMeta(ctx context.Context, n uint64) *cmttypes.BlockMeta {
 		return nil
 	}
 	// Assuming ToABCIBlockMeta is now in pkg/rpc/provider/provider_utils.go
-	bmeta, err := ToABCIBlockMeta(header, data) // Removed rpc. prefix
+	bmeta, err := common.ToABCIBlockMeta(header, data) // Removed rpc. prefix
 	if err != nil {
 		env.Logger.Error("Failed to convert block to ABCI block meta", "height", n, "err", err)
 		return nil
@@ -197,29 +88,6 @@ func filterMinMax(base, height, mini, maxi, limit int64) (int64, int64, error) {
 			errors.New("invalid request"), mini, maxi)
 	}
 	return mini, maxi, nil
-}
-
-// GetABCICommit returns a commit format defined by ABCI.
-// Other fields (especially ValidatorAddress and Timestamp of Signature) have to be filled by caller.
-func GetABCICommit(height uint64, hash rlktypes.Hash, val cmttypes.Address, time time.Time, signature rlktypes.Signature) *cmttypes.Commit {
-	tmCommit := cmttypes.Commit{
-		Height: int64(height), //nolint:gosec
-		Round:  0,
-		BlockID: cmttypes.BlockID{
-			Hash:          cmbytes.HexBytes(hash),
-			PartSetHeader: cmttypes.PartSetHeader{},
-		},
-		Signatures: make([]cmttypes.CommitSig, 1),
-	}
-	commitSig := cmttypes.CommitSig{
-		BlockIDFlag:      cmttypes.BlockIDFlagCommit,
-		Signature:        signature,
-		ValidatorAddress: val,
-		Timestamp:        time,
-	}
-	tmCommit.Signatures[0] = commitSig
-
-	return &tmCommit
 }
 
 // TruncateNodeID from rollkit we receive a 32 bytes node id, but we only need the first 20 bytes

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -5,7 +5,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	cmttypes "github.com/cometbft/cometbft/types"
+
 	"github.com/rollkit/go-execution-abci/pkg/common"
 )
 

--- a/pkg/rpc/core/utils_test.go
+++ b/pkg/rpc/core/utils_test.go
@@ -4,11 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTruncateNodeID(t *testing.T) {

--- a/pkg/rpc/core/utils_test.go
+++ b/pkg/rpc/core/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 
@@ -21,7 +22,7 @@ func TestTruncateNodeID(t *testing.T) {
 		expectedPrefix := fullNodeIDStr[:NodeIDByteLength*2] // First 20 bytes -> 40 chars
 
 		truncatedNodeID, err := TruncateNodeID(fullNodeIDStr)
-		assert.NoError(t, err, "TruncateNodeID should not return an error for a valid ID")
+		require.NoError(t, err, "TruncateNodeID should not return an error for a valid ID")
 		assert.Equal(t, NodeIDByteLength*2, len(truncatedNodeID), fmt.Sprintf("Truncated Node ID should be %d characters long", NodeIDByteLength*2))
 		assert.Equal(t, expectedPrefix, truncatedNodeID, "Truncated Node ID should be the first 20 bytes of the original ID")
 	})
@@ -37,12 +38,9 @@ func TestTruncateNodeID(t *testing.T) {
 	// Test case 3: Invalid hex string
 	t.Run("invalid hex string", func(t *testing.T) {
 		invalidHexStr := "not-a-hex-string-at-all-and-should-be-long-enough-to-pass-length-check"
-		// Ensure it would be long enough if it were hex
-		if len(invalidHexStr) < NodeIDByteLength*2 {
-			invalidHexStr = strings.Repeat("x", NodeIDByteLength*2) // Make it long enough but still invalid hex
-		}
+		require.GreaterOrEqual(t, len(invalidHexStr), NodeIDByteLength*2)
 		_, err := TruncateNodeID(invalidHexStr)
-		assert.Error(t, err, "TruncateNodeID should return an error for an invalid hex string")
+		require.Error(t, err, "TruncateNodeID should return an error for an invalid hex string")
 		assert.Contains(t, err.Error(), "failed to decode node ID", "Error message should indicate hex decoding failure")
 	})
 
@@ -56,7 +54,7 @@ func TestTruncateNodeID(t *testing.T) {
 	t.Run("exact length node ID", func(t *testing.T) {
 		exactLengthNodeIDStr := strings.Repeat("a", NodeIDByteLength*2) // 40 chars
 		truncatedNodeID, err := TruncateNodeID(exactLengthNodeIDStr)
-		assert.NoError(t, err, "TruncateNodeID should not return an error for an ID of exact length")
+		require.NoError(t, err, "TruncateNodeID should not return an error for an ID of exact length")
 		assert.Equal(t, exactLengthNodeIDStr, truncatedNodeID, "Truncated Node ID should be the same as input for exact length")
 	})
 }


### PR DESCRIPTION
After #88 to avoid merge conflicts in their branch

* Re-use existing logic to build comet abci types
* Create common package to avoid cyclic dependency


## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced utilities for converting Rollkit blockchain data structures to ABCI types, enabling easier integration with CometBFT.
  - Added transaction proof generation, providing Merkle proofs for transactions on demand.
- **Refactor**
  - Simplified and centralized block and header conversion logic by moving it to a shared utility package.
  - Updated tests to use helper functions for mock creation and improved test robustness with stricter assertions.
  - Refactored transaction-related code to modularize proof construction and improve error handling.
- **Chores**
  - Removed unused imports and redundant code for cleaner, more maintainable files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->