### PR TITLE
feat: add iterator on BlockchainInfo

### DIFF
--- a/pkg/rpc/core/blocks.go
+++ b/pkg/rpc/core/blocks.go
@@ -277,9 +277,6 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 
 	blocks := make([]*cmttypes.BlockMeta, 0, maxHeight-minHeight+1)
 	for _, block := range BlockIterator(maxHeight, minHeight) {
-		if err != nil {
-			return nil, err
-		}
 		if block.header != nil && block.data != nil {
 			cmblockmeta, err := common.ToABCIBlockMeta(block.header, block.data)
 			if err != nil {

--- a/pkg/rpc/core/blocks.go
+++ b/pkg/rpc/core/blocks.go
@@ -276,7 +276,7 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 	env.Logger.Debug("BlockchainInfo", "maxHeight", maxHeight, "minHeight", minHeight)
 
 	blocks := make([]*cmttypes.BlockMeta, 0, maxHeight-minHeight+1)
-	for _, block := range BlockIterator(maxHeight, minHeight) {
+	for _, block := range BlockIterator(ctx.Context(), maxHeight, minHeight) {
 		if block.header != nil && block.data != nil {
 			cmblockmeta, err := common.ToABCIBlockMeta(block.header, block.data)
 			if err != nil {

--- a/pkg/rpc/core/blocks.go
+++ b/pkg/rpc/core/blocks.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -11,6 +13,8 @@ import (
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	cmttypes "github.com/cometbft/cometbft/types"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
 
 	"github.com/rollkit/rollkit/block"
 	rlktypes "github.com/rollkit/rollkit/types"
@@ -276,13 +280,12 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 	env.Logger.Debug("BlockchainInfo", "maxHeight", maxHeight, "minHeight", minHeight)
 
 	blocks := make([]*cmttypes.BlockMeta, 0, maxHeight-minHeight+1)
-	for height := maxHeight; height >= minHeight; height-- {
-		header, data, err := env.Adapter.RollkitStore.GetBlockData(ctx.Context(), uint64(height))
+	for _, block := range BlockIterator(maxHeight, minHeight) {
 		if err != nil {
 			return nil, err
 		}
-		if header != nil && data != nil {
-			cmblockmeta, err := common.ToABCIBlockMeta(header, data)
+		if block.header != nil && block.data != nil {
+			cmblockmeta, err := common.ToABCIBlockMeta(block.header, block.data)
 			if err != nil {
 				return nil, err
 			}
@@ -294,4 +297,95 @@ func BlockchainInfo(ctx *rpctypes.Context, minHeight, maxHeight int64) (*ctypes.
 		LastHeight: int64(height), //nolint:gosec
 		BlockMetas: blocks,
 	}, nil
+}
+
+type BlockFilter struct { // needs this for the Filter interface
+	start int64
+	end   int64
+	field string //need this field for differentiation between getting headers and getting data
+}
+
+func (f *BlockFilter) Filter(e dsq.Entry) bool {
+	var height uint64
+	if f.field == "data" { //not great but necessary because we are not getting the same data
+		var block rlktypes.Data
+		err := json.Unmarshal(e.Value, &block)
+		if err != nil {
+			return false
+		}
+		height = block.Height()
+	}
+	if f.field == "header" {
+		var block rlktypes.SignedHeader
+		err := json.Unmarshal(e.Value, &block)
+		if err != nil {
+			return false
+		}
+		height = block.Height()
+	}
+
+	return height >= uint64(f.end) && height <= uint64(f.start)
+}
+
+func BlockIterator(start int64, end int64) []BlockResponse {
+	var blocks []BlockResponse
+	ds, ok := env.Adapter.RollkitStore.(ds.Batching)
+	if !ok {
+		return blocks
+	}
+	filter := &BlockFilter{start: start, end: end}
+
+	// we need to do two queries, one for the block header and one for the block data
+	qHeader := dsq.Query{
+		Prefix: "d",
+	}
+	qHeader.Filters = append(qHeader.Filters, filter)
+
+	qData := dsq.Query{
+		Prefix: "h",
+	}
+	qData.Filters = append(qData.Filters, filter)
+	// TODO: add sorting to get the result in the right order
+
+	rHeader, err := ds.Query(context.Background(), qHeader)
+	if err != nil {
+		return blocks
+	}
+	rData, err := ds.Query(context.Background(), qData)
+	if err != nil {
+		return blocks
+	}
+
+	headers, err := rHeader.Rest() // wait to get all the results, not needed but easier implementation for now
+	if err != nil {
+		return blocks
+	}
+	datas, err := rData.Rest()
+	if err != nil {
+		return blocks
+	}
+
+	for i := 0; i < len(headers); i++ {
+		header := new(rlktypes.SignedHeader)
+		err = header.UnmarshalBinary(headers[i].Value)
+		if err != nil {
+			continue
+		}
+
+		data := new(rlktypes.Data)
+		err = data.UnmarshalBinary(datas[i].Value)
+		if err != nil {
+			continue
+		}
+		// TODO: add a check that the heights are the same for the header and for the data
+		blocks = append(blocks, BlockResponse{header: header, data: data})
+		// here we do the assumption that the header and data results are sorted and that the heights are matching
+
+	}
+	return blocks
+}
+
+type BlockResponse struct {
+	header *rlktypes.SignedHeader
+	data   *rlktypes.Data
 }

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -3,12 +3,17 @@ package core
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	cmttypes "github.com/cometbft/cometbft/types"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
 
 	"github.com/rollkit/go-execution-abci/pkg/common"
+	rlktypes "github.com/rollkit/rollkit/types"
 )
 
 const NodeIDByteLength = 20
@@ -103,4 +108,102 @@ func TruncateNodeID(idStr string) (string, error) {
 		return "", fmt.Errorf("node ID too short, expected at least %d bytes, got %d", NodeIDByteLength, len(idBytes))
 	}
 	return hex.EncodeToString(idBytes[:NodeIDByteLength]), nil
+}
+
+func getHeightFromEntry(field string, value []byte) (uint64, error) {
+	if field == "data" {
+		var block rlktypes.Data
+		if err := json.Unmarshal(value, &block); err != nil {
+			return 0, err
+		}
+		return block.Height(), nil
+	} else if field == "header" {
+		var block rlktypes.SignedHeader
+		if err := json.Unmarshal(value, &block); err != nil {
+			return 0, err
+		}
+		return block.Height(), nil
+	}
+	return 0, fmt.Errorf("unknown field: %s", field)
+}
+
+type BlockFilter struct { // needs this for the Filter interface
+	start int64
+	end   int64
+	field string //need this field for differentiation between getting headers and getting data
+}
+
+func (f *BlockFilter) Filter(e dsq.Entry) bool {
+	height, err := getHeightFromEntry(f.field, e.Value)
+	if err != nil {
+		return false
+	}
+	return height >= uint64(f.end) && height <= uint64(f.start)
+}
+
+func BlockIterator(start int64, end int64) []BlockResponse {
+	var blocks []BlockResponse
+	ds, ok := env.Adapter.RollkitStore.(ds.Batching)
+	if !ok {
+		return blocks
+	}
+	filterData := &BlockFilter{start: start, end: end, field: "data"}
+	filterHeader := &BlockFilter{start: start, end: end, field: "header"}
+
+	// we need to do two queries, one for the block header and one for the block data
+	qHeader := dsq.Query{
+		Prefix: "h",
+	}
+	qHeader.Filters = append(qHeader.Filters, filterHeader)
+
+	qData := dsq.Query{
+		Prefix: "d",
+	}
+	qData.Filters = append(qData.Filters, filterData)
+	// TODO: add sorting to get the result in the right order
+
+	rHeader, err := ds.Query(context.Background(), qHeader)
+	if err != nil {
+		return blocks
+	}
+	rData, err := ds.Query(context.Background(), qData)
+	if err != nil {
+		return blocks
+	}
+
+	headerMap := make(map[uint64]*rlktypes.SignedHeader)
+	for h := range rHeader.Next() {
+		header := new(rlktypes.SignedHeader)
+		if err := header.UnmarshalBinary(h.Value); err != nil {
+			continue
+		}
+		headerMap[header.Height()] = header
+	}
+
+	dataMap := make(map[uint64]*rlktypes.Data)
+	for d := range rData.Next() {
+		data := new(rlktypes.Data)
+		if err := data.UnmarshalBinary(d.Value); err != nil {
+			continue
+		}
+		dataMap[data.Height()] = data
+	}
+
+	for height, header := range headerMap {
+		if data, ok := dataMap[height]; ok {
+			blocks = append(blocks, BlockResponse{header: header, data: data})
+		}
+	}
+
+	// Sort blocks by height descending
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].header.Height() > blocks[j].header.Height()
+	})
+
+	return blocks
+}
+
+type BlockResponse struct {
+	header *rlktypes.SignedHeader
+	data   *rlktypes.Data
 }

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -128,13 +128,13 @@ func getHeightFromEntry(field string, value []byte) (uint64, error) {
 	return 0, fmt.Errorf("unknown field: %s", field)
 }
 
-type BlockFilter struct { // needs this for the Filter interface
+type blockFilter struct { // needs this for the Filter interface
 	start int64
 	end   int64
 	field string //need this field for differentiation between getting headers and getting data
 }
 
-func (f *BlockFilter) Filter(e dsq.Entry) bool {
+func (f *blockFilter) Filter(e dsq.Entry) bool {
 	height, err := getHeightFromEntry(f.field, e.Value)
 	if err != nil {
 		return false
@@ -148,8 +148,8 @@ func BlockIterator(start int64, end int64) []BlockResponse {
 	if !ok {
 		return blocks
 	}
-	filterData := &BlockFilter{start: start, end: end, field: "data"}
-	filterHeader := &BlockFilter{start: start, end: end, field: "header"}
+	filterData := &blockFilter{start: start, end: end, field: "data"}
+	filterHeader := &blockFilter{start: start, end: end, field: "header"}
 
 	// we need to do two queries, one for the block header and one for the block data
 	qHeader := dsq.Query{
@@ -207,6 +207,8 @@ func BlockIterator(start int64, end int64) []BlockResponse {
 	return blocks
 }
 
+// BlockResponse represents a paired block header and data for efficient iteration.
+// It's returned by BlockIterator to provide access to both components of a block.
 type BlockResponse struct {
 	header *rlktypes.SignedHeader
 	data   *rlktypes.Data

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -114,17 +113,17 @@ func TruncateNodeID(idStr string) (string, error) {
 func getHeightFromEntry(field string, value []byte) (uint64, error) {
 	switch field {
 	case "data":
-		var block rlktypes.Data
-		if err := json.Unmarshal(value, &block); err != nil {
+		data := new(rlktypes.Data)
+		if err := data.UnmarshalBinary(value); err != nil {
 			return 0, err
 		}
-		return block.Height(), nil
+		return data.Height(), nil
 	case "header":
-		var block rlktypes.SignedHeader
-		if err := json.Unmarshal(value, &block); err != nil {
+		header := new(rlktypes.SignedHeader)
+		if err := header.UnmarshalBinary(value); err != nil {
 			return 0, err
 		}
-		return block.Height(), nil
+		return header.Height(), nil
 	}
 	return 0, fmt.Errorf("unknown field: %s", field)
 }

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -170,6 +170,8 @@ func BlockIterator(start int64, end int64) []BlockResponse {
 	if err != nil {
 		return blocks
 	}
+	defer rHeader.Close() //nolint:errcheck
+	defer rData.Close()   //nolint:errcheck
 
 	//we need to match the data to the header using the height, for that we use a map
 	headerMap := make(map[uint64]*rlktypes.SignedHeader)

--- a/pkg/rpc/core/utils.go
+++ b/pkg/rpc/core/utils.go
@@ -142,6 +142,11 @@ func (f *blockFilter) Filter(e dsq.Entry) bool {
 	return height >= uint64(f.min) && height <= uint64(f.max)
 }
 
+// BlockIterator returns a slice of BlockResponse objects containing paired headers and data
+// for blocks within the specified height range. It efficiently retrieves blocks by performing
+// only two datastore queries (one for headers, one for data) rather than querying each block
+// individually.
+// Returns a slice of BlockResponse objects sorted by height in descending order.
 func BlockIterator(ctx context.Context, max int64, min int64) []BlockResponse {
 	var blocks []BlockResponse
 	ds, ok := env.Adapter.RollkitStore.(ds.Batching)
@@ -218,4 +223,14 @@ func BlockIterator(ctx context.Context, max int64, min int64) []BlockResponse {
 type BlockResponse struct {
 	header *rlktypes.SignedHeader
 	data   *rlktypes.Data
+}
+
+// returns the block's signed header.
+func (br BlockResponse) Header() *rlktypes.SignedHeader {
+	return br.header
+}
+
+// returns the block's data.
+func (br BlockResponse) Data() *rlktypes.Data {
+	return br.data
 }


### PR DESCRIPTION
Closes #93

Add BlockIterator object to iterate over a range of blocks. This solves the N+1 query problem. Building BlockIterator only does two queries to the data-store (one for the headers and one for the datas).

Before:
```go
for height := maxHeight; height >= minHeight; height-- {
        header, data, err := env.Adapter.RollkitStore.GetBlockData(ctx.Context(), uint64(height))
        ...
}
```

Now:
```go
for _, block := range BlockIterator(maxHeight, minHeight) {
     header := block.header
     data := block.data
     ...
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved block querying and filtering, enabling users to view blocks within a specific height range.
  - Enhanced display of blockchain information by pairing block headers with their corresponding data.

- **Bug Fixes**
  - Increased reliability and accuracy when retrieving and displaying block information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->