### PR TITLE
fix(server): proper app exit

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -268,7 +268,7 @@ func (a *Adapter) InitChain(ctx context.Context, genesisTime time.Time, initialH
 		return nil, 0, fmt.Errorf("failed to save initial state: %w", err)
 	}
 
-	a.Logger.Info("Chain initialized successfully", "appHash", fmt.Sprintf("%X", res.AppHash))
+	a.Logger.Info("chain initialized successfully", "appHash", fmt.Sprintf("%X", res.AppHash))
 	return res.AppHash, uint64(s.ConsensusParams.Block.MaxBytes), nil
 }
 
@@ -407,7 +407,7 @@ func (a *Adapter) ExecuteTxs(
 	block := s.MakeBlock(int64(blockHeight), cmtTxs, &cmttypes.Commit{Height: int64(blockHeight)}, nil, s.Validators.Proposer.Address)
 	fireEvents(a.Logger, a.EventBus, block, cmttypes.BlockID{}, fbResp, validatorUpdates)
 
-	a.Logger.Info("Block executed successfully", "height", blockHeight, "appHash", fmt.Sprintf("%X", fbResp.AppHash))
+	a.Logger.Info("block executed successfully", "height", blockHeight, "appHash", fmt.Sprintf("%X", fbResp.AppHash))
 	return fbResp.AppHash, uint64(s.ConsensusParams.Block.MaxBytes), nil
 }
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -519,5 +519,5 @@ func (a *Adapter) GetTxs(ctx context.Context) ([][]byte, error) {
 // SetFinal handles extra logic once the block has been finalized (posted to DA).
 // For a Cosmos SDK app, this is a no-op we do not need to do anything to mark the block as finalized.
 func (a *Adapter) SetFinal(ctx context.Context, blockHeight uint64) error {
-	return nil
+	return errors.New("error in execution: SetFinal trigger")
 }

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -47,7 +47,7 @@ func (r *RPCServer) Start() error {
 
 func (r *RPCServer) startRPC() error {
 	if r.config.ListenAddress == "" {
-		r.logger.Info("Listen address not specified - RPC will not be exposed")
+		r.logger.Info("listen address not specified - RPC will not be exposed")
 		return nil
 	}
 	parts := strings.SplitN(r.config.ListenAddress, "://", 2)
@@ -109,7 +109,6 @@ func (r *RPCServer) serve(listener net.Listener, handler http.Handler) error {
 
 // Stop stops the RPC server gracefully.
 func (r *RPCServer) Stop() error {
-	r.logger.Info("Stopping RPC server")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -117,6 +116,7 @@ func (r *RPCServer) Stop() error {
 		r.logger.Error("RPC server shutdown error", "err", err)
 		return err
 	}
+
 	r.logger.Info("RPC server stopped")
 	return nil
 }

--- a/server/start.go
+++ b/server/start.go
@@ -141,9 +141,9 @@ func startInProcess(svrCtx *server.Context, svrCfg serverconfig.Config, clientCt
 			}
 
 			if err == context.Canceled {
-				svrCtx.Logger.Info("Rollkit node run loop cancelled by context")
+				svrCtx.Logger.Info("rollkit node run loop cancelled by context")
 			} else {
-				svrCtx.Logger.Info("Rollkit node run loop completed")
+				svrCtx.Logger.Info("rollkit node run loop completed")
 			}
 
 			// cancel context to stop all other processes
@@ -151,7 +151,7 @@ func startInProcess(svrCtx *server.Context, svrCfg serverconfig.Config, clientCt
 
 			return nil
 		})
-		svrCtx.Logger.Info("Rollkit node run loop launched in background goroutine")
+		svrCtx.Logger.Info("rollkit node run loop launched in background goroutine")
 
 		// Wait for the node to start p2p before attempting to start the gossiper
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Overview

Now that that rollkit is properly stopping when the app has an error, it looks like the error group is still waiting for the grpc server to stop. We should cancel the context here.